### PR TITLE
Added support for irssi-generated log files

### DIFF
--- a/resources/formats/irssi.cfg
+++ b/resources/formats/irssi.cfg
@@ -1,0 +1,4 @@
+said line	=	^[0-9]{2}:[0-9]{2}\s<[@+~&|\s]{0,1}(?P<nickname>[A-Za-z_-\|0-9]+)>\s(?P<words>.+)
+action line	=	^[0-9]{2}:[0-9]{2}\s\s\*\s(?P<nickname>[A-Za-z_-\|0-9]+)\s(?P<words>.+)
+
+time		=	^(?P<hour>[0-9]{2}):(?P<minute>[0-9]{2})\s(.*)

--- a/resources/htmlout.py
+++ b/resources/htmlout.py
@@ -62,6 +62,9 @@ numberre        = re.compile("%number%"     )
 def timePercents(check):
     """Returns a tuple of the percentages of lines posted between 0 and 6, 6 and 12, 12 and 18, and 18 and 0, respectively."""
     totaltimelines = float(sum(check.times.values()))
+    
+    if totaltimelines == 0: return 0.0, 0.0, 0.0, 0.0; # Avoid division by zero below
+    
     time1 = (sum((x[1] for x in check.times_ordered[:6])) / totaltimelines) * 100
     time2 = (sum((x[1] for x in check.times_ordered[6:12])) / totaltimelines) * 100
     time3 = (sum((x[1] for x in check.times_ordered[12:18])) / totaltimelines) * 100


### PR DESCRIPTION
Generating log files with irssi can be turned on via '/set autolog on'. As irssi allows you to define custom formats of the log files with regular expressions, this irssi.cfg is only suitable for the default log format – which however is very commonly used.