### PR TITLE
Correctly decode string in lineSort

### DIFF
--- a/resources/confutil.py
+++ b/resources/confutil.py
@@ -71,7 +71,7 @@ def lineSort(filename):
     nonempty = [line.rstrip() for line in lines if line.strip() and line.strip()[0:2] != '##']
     nonempty.sort()
     sortfile = io.open(filename, 'w', encoding='utf-8-sig')
-    sortfile.write('\n'.join(nonempty) + '\n')
+    sortfile.write(('\n'.join(nonempty) + '\n').decode('utf-8'))
     sortfile.close()
 
 def stringToBool(s):


### PR DESCRIPTION
This fixes a stacktrace the first time the application is run:

```
$ python pycs.py
Traceback (most recent call last):
  File "pycs.py", line 10, in <module>
    from generate import *
  File "/home/louis/git/pycs/resources/generate.py", line 6, in <module>
    import startops ## Initializing program with variables and such
  File "/home/louis/git/pycs/resources/startops.py", line 85, in <module>
    confutil.createConfig(aliases, os.path.join(pycspath, 'settings', 'aliases.cfg'))
  File "/home/louis/git/pycs/resources/confutil.py", line 47, in createConfig
    lineSort(filename)
  File "/home/louis/git/pycs/resources/confutil.py", line 74, in lineSort
    sortfile.write('\n'.join(nonempty) + '\n')
TypeError: must be unicode, not str
```
